### PR TITLE
Fix grasp checking doesn't work when z is not part of the action in numpy. 

### DIFF
--- a/envs/base_env.py
+++ b/envs/base_env.py
@@ -50,6 +50,8 @@ class BaseEnv(object):
     assert action_sequence.find('y') != -1
     self.action_sequence = action_sequence
 
+    self.offset = 0.01
+
   def _getSpecificAction(self, action):
     """
     decode input action base on self.action_sequence
@@ -75,7 +77,7 @@ class BaseEnv(object):
     elif shape_type == self.CONE: return 'cone'
     else: return 'unknown'
 
-  def _getPrimativeHeight(self, motion_primative, x, y, offset=0.01):
+  def _getPrimativeHeight(self, motion_primative, x, y):
     '''
     Get the z position for the given action using the current heightmap.
     Args:
@@ -89,7 +91,7 @@ class BaseEnv(object):
     local_region = self.heightmap[max(y_pixel - 30, 0):min(y_pixel + 30, self.heightmap_size), \
                                   max(x_pixel - 30, 0):min(x_pixel + 30, self.heightmap_size)]
     safe_z_pos = np.max(local_region) + self.workspace[2][0]
-    safe_z_pos = safe_z_pos - offset if motion_primative == self.PICK_PRIMATIVE else safe_z_pos + offset
+    safe_z_pos = safe_z_pos - self.offset if motion_primative == self.PICK_PRIMATIVE else safe_z_pos + self.offset
 
     return safe_z_pos
 

--- a/envs/numpy_env.py
+++ b/envs/numpy_env.py
@@ -9,6 +9,7 @@ class NumpyEnv(BaseEnv):
     super(NumpyEnv, self).__init__(seed, workspace, max_steps, heightmap_size, action_sequence)
 
     self.render = render
+    self.offset = self.heightmap_size/20
 
   def reset(self):
     ''''''
@@ -54,7 +55,6 @@ class NumpyEnv(BaseEnv):
     for obj in height_sorted_objects:
       if obj.isGraspValid([x,y,z], rot):
         obj.removeFromHeightmap(self.heightmap)
-        self.objects.remove(obj)
         return obj
 
     return None
@@ -78,9 +78,10 @@ class NumpyEnv(BaseEnv):
 
       is_position_valid = False
       while not is_position_valid:
-        position = [int((x_extents - padding) * npr.random_sample() + self.workspace[0][0] + padding / 2),
-                    int((y_extents - padding) * npr.random_sample() + self.workspace[1][0] + padding / 2),
-                    0]
+        # position = [int((x_extents - padding) * npr.random_sample() + self.workspace[0][0] + padding / 2),
+        #             int((y_extents - padding) * npr.random_sample() + self.workspace[1][0] + padding / 2),
+        #             0]
+        position = [100, 200, 0]
         if positions:
           is_position_valid = np.all(np.sum(np.abs(np.array(positions) - np.array(position)), axis=1) > min_distance)
         else:
@@ -88,7 +89,8 @@ class NumpyEnv(BaseEnv):
 
       positions.append(position)
       if random_orientation:
-        rotation = np.pi*np.random.random_sample()
+        # rotation = np.pi*np.random.random_sample()
+        rotation = 0.0
       else:
         rotation = 0.0
       size = npr.randint(self.heightmap_size/10, self.heightmap_size/7)

--- a/envs/numpy_env.py
+++ b/envs/numpy_env.py
@@ -78,10 +78,9 @@ class NumpyEnv(BaseEnv):
 
       is_position_valid = False
       while not is_position_valid:
-        # position = [int((x_extents - padding) * npr.random_sample() + self.workspace[0][0] + padding / 2),
-        #             int((y_extents - padding) * npr.random_sample() + self.workspace[1][0] + padding / 2),
-        #             0]
-        position = [100, 200, 0]
+        position = [int((x_extents - padding) * npr.random_sample() + self.workspace[0][0] + padding / 2),
+                    int((y_extents - padding) * npr.random_sample() + self.workspace[1][0] + padding / 2),
+                    0]
         if positions:
           is_position_valid = np.all(np.sum(np.abs(np.array(positions) - np.array(position)), axis=1) > min_distance)
         else:
@@ -89,8 +88,7 @@ class NumpyEnv(BaseEnv):
 
       positions.append(position)
       if random_orientation:
-        # rotation = np.pi*np.random.random_sample()
-        rotation = 0.0
+        rotation = np.pi*np.random.random_sample()
       else:
         rotation = 0.0
       size = npr.randint(self.heightmap_size/10, self.heightmap_size/7)

--- a/numpy_toolkit/object_generation.py
+++ b/numpy_toolkit/object_generation.py
@@ -39,7 +39,7 @@ class Cube(object):
       valid_rot2 = valid_rot1 - np.pi/2
     return np.allclose(grasp_pos[:-1], self.pos[:-1], atol=(self.size/2)) and \
            (np.abs(grasp_rot-valid_rot1) < np.pi/8 or np.abs(grasp_rot-valid_rot2) < np.pi/8) and \
-           grasp_pos[-1] < self.pos[-1]
+           grasp_pos[-1] < self.size
 
 #=================================================================================================#
 #                                         Generation                                              #

--- a/tests/test_numpy_env.py
+++ b/tests/test_numpy_env.py
@@ -9,13 +9,13 @@ workspace = np.asarray([[0, 250],
                         [0, 250],
                         [0, 500]])
 
-env_config = {'workspace': workspace, 'max_steps': 10, 'obs_size': 250, 'render': True, 'action_sequence': 'xyzr'}
+env_config = {'workspace': workspace, 'max_steps': 10, 'obs_size': 250, 'render': True, 'action_sequence': 'xyr'}
 envs = env_factory.createEnvs(1, 'numpy', 'block_picking', env_config)
 
 for i in range(8):
   states, obs = envs.reset()
   plt.imshow(obs.squeeze(), cmap='gray')
-  actions = torch.tensor([[100, 200, i * 10, i * np.pi/8]])
+  actions = torch.tensor([[100, 200, i * np.pi/8]])
   plt.show()
   states_, obs_, rewards, dones = envs.step(actions)
   pass


### PR DESCRIPTION
Add offset attribute in base class for function _getPrimativeHeight. Previous default offset parameter in _getPrimativeHeight is 0.01 for all envs, which doesn't work in numpy