### PR TITLE
Fix inaccurate IK and gripper loose during transit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/envs/pybullet_env.py
+++ b/envs/pybullet_env.py
@@ -25,7 +25,7 @@ class PyBulletEnv(BaseEnv):
     self.dynamic = not fast_mode
 
     # Environment specific variables
-    self._timestep = 1. / 360.
+    self._timestep = 1. / 240.
     self.ur5 = UR5_RG2()
     self.pick_offset = 0.25
     self.place_offset = 0.25
@@ -128,7 +128,7 @@ class PyBulletEnv(BaseEnv):
       else:
         orientation = pb.getQuaternionFromEuler([0., 0., 0.])
 
-      scale = npr.uniform(0.5, 0.7)
+      scale = npr.uniform(0.7, 1.0)
 
       handle = pb_obj_generation.generateCube(position, orientation, scale)
       shape_handles.append(handle)

--- a/envs/pybullet_env.py
+++ b/envs/pybullet_env.py
@@ -128,7 +128,7 @@ class PyBulletEnv(BaseEnv):
       else:
         orientation = pb.getQuaternionFromEuler([0., 0., 0.])
 
-      scale = npr.uniform(0.7, 1.0)
+      scale = npr.uniform(0.5, 0.7)
 
       handle = pb_obj_generation.generateCube(position, orientation, scale)
       shape_handles.append(handle)

--- a/pybullet_toolkit/robots/ur5_rg2.py
+++ b/pybullet_toolkit/robots/ur5_rg2.py
@@ -16,9 +16,9 @@ class UR5_RG2(object):
   '''
   def __init__(self):
     # Setup arm and gripper variables
-    self.max_forces = [150, 150, 150, 28, 28, 28, 500, 500]
-    self.gripper_close_force = [500] * 2
-    self.gripper_open_force = [500] * 2
+    self.max_forces = [150, 150, 150, 28, 28, 28, 100, 100]
+    self.gripper_close_force = [100] * 2
+    self.gripper_open_force = [100] * 2
     self.end_effector_index = 12
 
     self.home_positions = [0., 0., -2.137, 1.432, -0.915, -1.591, 0.071, 0., 0., 0., 0., 0., 0., 0.]
@@ -114,36 +114,6 @@ class UR5_RG2(object):
       new_rot = list(ls[5])
       close_enough = np.allclose(np.array(new_pos + new_rot), np.array(list(pos) + list(rot)), atol=threshold)
       it += 1
-    pass
-
-    # # ik_solve = pb.calculateInverseKinematics(self.id, self.end_effector_index, pos, rot)
-    # ik_solve = self.accurateCalculateInverseKinematics(pos, rot, 1e-4, 1000)
-    # if dynamic:
-    #   ee_pos = self._getEndEffectorPosition()
-    #   ee_rot = self._getEndEffectorRotation()
-    #   self._sendPositionCommand(ik_solve)
-    #   past_ee_pos = deque(maxlen=5)
-    #   past_ee_rot = deque(maxlen=5)
-    #   while not (np.allclose(ee_pos, pos, atol=0.01) and np.allclose(ee_rot, rot, atol=0.01)):
-    #     # time.sleep(0.005)
-    #     pb.stepSimulation()
-    #
-    #     # Check to see if the arm can't move any close to the desired position
-    #     if len(past_ee_pos) == 5 and np.allclose(past_ee_pos[0], past_ee_pos, 1e-3) \
-    #         and len(past_ee_rot) == 5 and np.allclose(past_ee_rot[0], past_ee_rot, 1e-3):
-    #     # if len(past_ee_pos) == 5 and np.allclose(past_ee_pos[0], past_ee_pos):
-    #       js = pb.getJointStates(self.id, self.motor_indices)
-    #       jp = list(zip(*js))[0]
-    #       error = np.array(ik_solve) - jp
-    #       print(max(error))
-    #       break
-    #
-    #     past_ee_pos.append(ee_pos)
-    #     past_ee_rot.append(ee_rot)
-    #     ee_pos = self._getEndEffectorPosition()
-    #     ee_rot = self._getEndEffectorRotation()
-    # else:
-    #   self._setJointPoses(ik_solve)
 
   def closeGripper(self):
     ''''''

--- a/pybullet_toolkit/robots/ur5_rg2.py
+++ b/pybullet_toolkit/robots/ur5_rg2.py
@@ -82,12 +82,12 @@ class UR5_RG2(object):
 
   def moveTo(self, pos, rot, dynamic=True):
     ''''''
-    closeEnough = False
+    close_enough = False
     it = 0
     threshold = 1e-3
     max_iteration = 100
 
-    while not closeEnough and it < max_iteration:
+    while not close_enough and it < max_iteration:
       ik_solve = pb.calculateInverseKinematics(self.id, self.end_effector_index, pos, rot)[:-2]
       if dynamic:
         self._sendPositionCommand(ik_solve)
@@ -108,9 +108,7 @@ class UR5_RG2(object):
       ls = pb.getLinkState(self.id, self.end_effector_index)
       new_pos = list(ls[4])
       new_rot = list(ls[5])
-      diff = np.array(new_pos + new_rot) - np.array(list(pos) + list(rot))
-      diff = np.abs(diff).mean()
-      closeEnough = (diff < threshold)
+      close_enough = np.allclose(np.array(new_pos + new_rot), np.array(list(pos) + list(rot)), atol=threshold)
       it += 1
     pass
 

--- a/pybullet_toolkit/robots/ur5_rg2.py
+++ b/pybullet_toolkit/robots/ur5_rg2.py
@@ -34,19 +34,18 @@ class UR5_RG2(object):
     self.num_joints = pb.getNumJoints(self.id)
     [pb.resetJointState(self.id, idx, self.home_positions[idx]) for idx in range(self.num_joints)]
 
-    self.motor_names = list()
-    self.motor_indices = list()
+    self.gripper_joint_names = list()
+    self.gripper_joint_indices = list()
     self.arm_joint_names = list()
     self.arm_joint_indices = list()
     for i in range (self.num_joints):
       joint_info = pb.getJointInfo(self.id, i)
-      q_index = joint_info[3]
       if i in range(1, 7):
         self.arm_joint_names.append(str(joint_info[1]))
         self.arm_joint_indices.append(i)
-      if q_index > -1:
-        self.motor_names.append(str(joint_info[1]))
-        self.motor_indices.append(i)
+      elif i in range(7, 9):
+        self.gripper_joint_names.append(str(joint_info[1]))
+        self.gripper_joint_indices.append(i)
 
   def pick(self, pos, rot, offset, dynamic=True):
     ''''''
@@ -168,6 +167,7 @@ class UR5_RG2(object):
 
   def _setJointPoses(self, q_poses):
     ''''''
+    motor_indices = self.arm_joint_indices + self.gripper_joint_indices
     for i in range(len(q_poses)):
-      motor = self.motor_indices[i]
+      motor = motor_indices[i]
       pb.resetJointState(self.id, motor, q_poses[i])

--- a/pybullet_toolkit/robots/ur5_rg2.py
+++ b/pybullet_toolkit/robots/ur5_rg2.py
@@ -30,6 +30,7 @@ class UR5_RG2(object):
     ur5_urdf_filepath = os.path.join(self.root_dir, 'urdf/ur5/ur5_w_simple_gripper.urdf')
     self.id = pb.loadURDF(ur5_urdf_filepath, [0,0,0], [0,0,0,1])
     self.is_holding = False
+    self.gripper_closed = False
     self.num_joints = pb.getNumJoints(self.id)
     [pb.resetJointState(self.id, idx, self.home_positions[idx]) for idx in range(self.num_joints)]
 
@@ -145,6 +146,7 @@ class UR5_RG2(object):
     ''''''
     p1 = pb.getJointState(self.id, 10)[0]
     pb.setJointMotorControlArray(self.id, [10,11], pb.VELOCITY_CONTROL, targetVelocities=[1.0, 1.0], forces=self.gripper_close_force)
+    self.gripper_closed = True
     while p1 < 0.036:
       pb.stepSimulation()
       p1_ = pb.getJointState(self.id, 10)[0]
@@ -158,7 +160,7 @@ class UR5_RG2(object):
     ''''''
     p1 = pb.getJointState(self.id, 10)[0]
     pb.setJointMotorControlArray(self.id, [10,11], pb.VELOCITY_CONTROL, targetVelocities=[-1.0, -1.0], forces=self.gripper_open_force)
-
+    self.gripper_closed = False
     while p1 > 0.0:
       pb.stepSimulation()
       p1 = pb.getJointState(self.id, 10)[0]
@@ -177,6 +179,8 @@ class UR5_RG2(object):
     num_motors = len(self.motor_indices)
     pb.setJointMotorControlArray(self.id, self.motor_indices, pb.POSITION_CONTROL, commands,
                                  [0.]*num_motors, self.max_forces, [0.01]*num_motors, [1.0]*num_motors)
+    if self.gripper_closed:
+      self.closeGripper()
 
   def _setJointPoses(self, q_poses):
     ''''''

--- a/pybullet_toolkit/robots/ur5_rg2.py
+++ b/pybullet_toolkit/robots/ur5_rg2.py
@@ -48,7 +48,7 @@ class UR5_RG2(object):
     pre_pos = copy.copy(pos)
     pre_pos[2] += offset
     # rot = pb.getQuaternionFromEuler([np.pi/2.,-np.pi,np.pi/2])
-    pre_rot = pb.getQuaternionFromEuler([0, np.pi, 0])
+    pre_rot = rot
 
     # Move to pre-grasp pose and then grasp pose
     self.moveTo(pre_pos, pre_rot, dynamic)


### PR DESCRIPTION
1. Change the logic of function 'moveTo' to iteratively solve IK and approach to the goal position. Calling IK once can not get accurate solution. 
2. Keep a flag of if gripper is supposed to be closed or not. After sending position command and gripper is supposed to be closed, send another velocity command to gripper.
3. Remove the gripper position command while moving arm to some goal position
4. Fix bug that pre_rot is different from rot in picking
