### PR TITLE
Add 'min_object_distance', 'min_boarder_padding', and 'deconstruct_init_offset' parameters; change default padding; and bug fix

### DIFF
--- a/helping_hands_rl_envs/envs/pybullet_envs/constants.py
+++ b/helping_hands_rl_envs/envs/pybullet_envs/constants.py
@@ -24,4 +24,6 @@ DEFAULT_CONFIG = {
   'num_objects' : 1,
   'object_type' : 'cube',
   'hard_reset_freq': 1,
+  'min_object_distance': None,
+  'min_boarder_padding': None,
 }

--- a/helping_hands_rl_envs/envs/pybullet_envs/constants.py
+++ b/helping_hands_rl_envs/envs/pybullet_envs/constants.py
@@ -26,4 +26,8 @@ DEFAULT_CONFIG = {
   'hard_reset_freq': 1,
   'min_object_distance': None,
   'min_boarder_padding': None,
+  # The random offset range for each object when generating the goal structure. This will help to reduce the domain gap
+  # (because when constructing, the objects are aligned less perfectly), but will also decrease the optimality of the expert.
+  # This is the sum of the + and - amount, e.g., for 0.005, the offset will be randomly sampled from -0.0025 to 0.0025
+  'deconstruct_init_offset': 0,
 }

--- a/helping_hands_rl_envs/envs/pybullet_envs/deconstruct_env.py
+++ b/helping_hands_rl_envs/envs/pybullet_envs/deconstruct_env.py
@@ -93,6 +93,13 @@ class DeconstructEnv(PyBulletEnv):
   def generateStructureShape(self, pos, rot, obj_type, scale=None):
     '''
     '''
+    # add the random initialization offset
+    x_offset = (np.random.random()-1) * self.deconstruct_init_offset
+    y_offset = (np.random.random()-1) * self.deconstruct_init_offset
+    pos = list(pos)
+    pos[0] += x_offset
+    pos[1] += y_offset
+
     if scale is None:
       scale = npr.choice(np.arange(self.block_scale_range[0], self.block_scale_range[1] + 0.01, 0.02))
 

--- a/helping_hands_rl_envs/envs/pybullet_envs/pybullet_env.py
+++ b/helping_hands_rl_envs/envs/pybullet_envs/pybullet_env.py
@@ -111,6 +111,7 @@ class PyBulletEnv(BaseEnv):
     self.hard_reset_freq = config['hard_reset_freq']
     self.min_object_distance = config['min_object_distance']
     self.min_boarder_padding = config['min_boarder_padding']
+    self.deconstruct_init_offset = config['deconstruct_init_offset']
 
     self.episode_count = -1
     self.table_id = None

--- a/helping_hands_rl_envs/envs/pybullet_envs/pybullet_env.py
+++ b/helping_hands_rl_envs/envs/pybullet_envs/pybullet_env.py
@@ -407,7 +407,7 @@ class PyBulletEnv(BaseEnv):
     ''''''
     if padding is None:
       if shape_type in (constants.CUBE, constants.TRIANGLE, constants.RANDOM, constants.CYLINDER):
-        padding = self.max_block_size * 3.5
+        padding = self.max_block_size * 2.4
       elif shape_type == constants.BRICK:
         padding = self.max_block_size * 3.4
       elif shape_type == constants.ROOF:

--- a/helping_hands_rl_envs/planners/block_structure_base_planner.py
+++ b/helping_hands_rl_envs/planners/block_structure_base_planner.py
@@ -42,7 +42,7 @@ class BlockStructureBasePlanner(BasePlanner):
     x, y, z, r = object_poses[0][0], object_poses[0][1], object_poses[0][2], object_poses[0][5]
     for obj, pose in zip(objects, object_poses):
       if self.isObjOnTop(obj):
-        x, y, z, r = pose[0], pose[1], pose[2]+self.env.pick_offset, pose[5]
+        x, y, z, r = pose[0], pose[1], pose[2], pose[5]
         break
 
     return self.encodeAction(constants.PICK_PRIMATIVE, x, y, z, r)
@@ -59,7 +59,7 @@ class BlockStructureBasePlanner(BasePlanner):
     x, y, z, r = object_poses[0][0], object_poses[0][1], object_poses[0][2], object_poses[0][5]
     for obj, pose in zip(objects, object_poses):
       if self.isObjOnTop(obj):
-        x, y, z, r = pose[0], pose[1], pose[2]+self.env.pick_offset, pose[5]
+        x, y, z, r = pose[0], pose[1], pose[2], pose[5]
         break
 
     return self.encodeAction(constants.PICK_PRIMATIVE, x, y, z, r)


### PR DESCRIPTION
1. Add  'min_object_distance' and 'min_boarder_padding' parameters. When they are set, the min distance and padding while generating objects will not be any smaller
2. Add 'deconstruct_init_offset' parameter. It controls the random offset range for each object when initializing the deconstruction structure. This will help to reduce the domain gap (because when constructing, the objects are aligned less perfectly compared to the deconstruction initialization), but will also decrease the optimality of the expert.
2. Change the default padding of cube from 3.4 * max_block_size to 2.4 * max_block_size. Resolves #32 
3. Fix a bug in the planner when z is in the action space